### PR TITLE
fix(provider): use FCU canonical head for latest state provider (tag: reth:1.9.3-fcu-fix-20251215)

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -1158,7 +1158,25 @@ where
             // forkchoiceState.headBlockHash, validationError: null}, payloadId: null}`
 
             // The head block is already canonical and we're not processing payload attributes,
-            // so we're not triggering a payload job and can return right away
+            // so we're not triggering a payload job and can return right away.
+            //
+            // However, if FCU is targeting a different block than current head (reorg scenario),
+            // we must update the canonical head so state providers use the correct chain state.
+            // This prevents "nonce too low" errors when transactions are resubmitted after reorg.
+            // This handles both:
+            // - Reorg to ancestor (lower block number)
+            // - Same-height reorg (same number, different hash)
+            let current_head = self.state.tree_state.canonical_head();
+            if canonical_header.num_hash() != *current_head {
+                debug!(
+                    target: "engine::tree",
+                    ?current_head,
+                    new_head = ?canonical_header.num_hash(),
+                    "FCU targets different canonical block, updating head for correct state lookups"
+                );
+                self.state.tree_state.set_canonical_head(canonical_header.num_hash());
+                self.canonical_in_memory_state.set_canonical_head(canonical_header.clone());
+            }
 
             let outcome = TreeOutcome::new(OnForkChoiceUpdated::valid(PayloadStatus::new(
                 PayloadStatusEnum::Valid,

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -493,12 +493,14 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
     /// Storage provider for latest block
     fn latest(&self) -> ProviderResult<StateProviderBox> {
         trace!(target: "providers::blockchain", "Getting latest block state provider");
-        // use latest state provider if the head state exists
-        if let Some(state) = self.canonical_in_memory_state.head_state() {
-            trace!(target: "providers::blockchain", "Using head state for latest state provider");
-            Ok(self.block_state_provider(&state)?.boxed())
+
+        // Use canonical head from FCU tracker (not highest-numbered block)
+        let canonical_head_hash = self.canonical_in_memory_state.get_canonical_head().hash();
+
+        if let Some(state) = self.canonical_in_memory_state.state_by_hash(canonical_head_hash) {
+            Ok(Box::new(self.block_state_provider(&state)?))
         } else {
-            trace!(target: "providers::blockchain", "Using database state for latest state provider");
+            trace!(target: "providers::blockchain", ?canonical_head_hash, "Canonical head not in memory, using database");
             self.database.latest()
         }
     }


### PR DESCRIPTION
## Summary

- Fix `BlockchainProvider::latest()` to use canonical head from FCU tracker instead of highest-numbered block
- Prevents transaction pool desynchronization during reorgs

## Problem

During reorgs, `head_state()` returns the highest-numbered block in memory via `numbers.last_key_value()`, not the FCU-specified canonical head. This causes:
1. `eth_getBlockByNumber("latest")` to return wrong block
2. Transaction validation against incorrect state
3. "Nonce too low" errors for valid transactions

## Solution

Use `get_canonical_head().hash()` + `state_by_hash()` instead of `head_state()` to ensure the latest state provider always reflects the consensus layer's view of the canonical chain.

## Test plan

- [x] `cargo test -p reth-provider` passes
- [x] `cargo test -p reth-chain-state` passes
- [x] `cargo +nightly fmt --all` passes
- [x] `cargo clippy -p reth-provider --all-features` passes